### PR TITLE
Let jax load it automatically

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ dependencies = [
     "jax>=0.6.0",
 ]
 
+[project.entry-points.jax_plugins]
+mpibackend4jax = "mpibackend4jax"
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/mpibackend4jax"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
 ]
 
 [project.entry-points.jax_plugins]
-mpibackend4jax = "mpibackend4jax"
+mpibackend4jax = "mpibackend4jax.plugin"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/mpibackend4jax"]

--- a/src/mpibackend4jax/__init__.py
+++ b/src/mpibackend4jax/__init__.py
@@ -8,23 +8,24 @@ by setting the required environment variables when imported.
 import os
 
 # Import the cluster to register it automatically
-# from .mpitrampoline_cluster import MPITrampolineLocalCluster
+from .mpitrampoline_cluster import MPITrampolineLocalCluster
 
 __version__ = "0.1.0"
 
-# # Convenience function to check if MPITrampoline is properly configured
-# def is_configured():
-#     """Check if MPITrampoline is properly configured for JAX"""
-#     return (
-#         "MPITRAMPOLINE_LIB" in os.environ
-#         and os.environ.get("JAX_CPU_COLLECTIVES_IMPLEMENTATION") == "mpi"
-#         and Path(os.environ["MPITRAMPOLINE_LIB"]).exists()
-#     )
-#
-#
-# def get_library_path():
-#     """Get the path to the MPIWrapper library"""
-#     return os.environ.get("MPITRAMPOLINE_LIB")
+
+# Convenience function to check if MPITrampoline is properly configured
+def is_configured():
+    """Check if MPITrampoline is properly configured for JAX"""
+    return (
+        "MPITRAMPOLINE_LIB" in os.environ
+        and os.environ.get("JAX_CPU_COLLECTIVES_IMPLEMENTATION") == "mpi"
+        and Path(os.environ["MPITRAMPOLINE_LIB"]).exists()
+    )
 
 
-#__all__ = ["is_configured", "get_library_path"], "MPITrampolineLocalCluster"]
+def get_library_path():
+    """Get the path to the MPIWrapper library"""
+    return os.environ.get("MPITRAMPOLINE_LIB")
+
+
+__all__ = ["is_configured", "get_library_path", "MPITrampolineLocalCluster"]

--- a/src/mpibackend4jax/__init__.py
+++ b/src/mpibackend4jax/__init__.py
@@ -20,11 +20,12 @@ def initialize():
 
     # Set environment variables for MPITrampoline
     if _mpiwrapper_lib.exists():
-        os.environ["MPITRAMPOLINE_LIB"] = str(_mpiwrapper_lib.absolute())
-        os.environ["JAX_CPU_COLLECTIVES_IMPLEMENTATION"] = "mpi"
-
-        print(f"mpibackend4jax: Set MPITRAMPOLINE_LIB={_mpiwrapper_lib.absolute()}")
-        print("mpibackend4jax: Set JAX_CPU_COLLECTIVES_IMPLEMENTATION=mpi")
+        if "MPITRAMPOLINE_LIB" not in os.environ.keys():
+            os.environ["MPITRAMPOLINE_LIB"] = str(_mpiwrapper_lib.absolute())
+            print(f"mpibackend4jax: Set MPITRAMPOLINE_LIB={_mpiwrapper_lib.absolute()}")
+        if "JAX_CPU_COLLECTIVES_IMPLEMENTATION" not in os.environ.keys()
+            os.environ["JAX_CPU_COLLECTIVES_IMPLEMENTATION"] = "mpi"
+            print("mpibackend4jax: Set JAX_CPU_COLLECTIVES_IMPLEMENTATION=mpi")
     else:
         print(f"Warning: MPIWrapper library not found at {_mpiwrapper_lib}")
         print("Please ensure the package was installed correctly.")

--- a/src/mpibackend4jax/__init__.py
+++ b/src/mpibackend4jax/__init__.py
@@ -45,4 +45,4 @@ def initialize():
 #     return os.environ.get("MPITRAMPOLINE_LIB")
 
 
-__all__ = ["is_configured", "get_library_path"]#, "MPITrampolineLocalCluster"]
+#__all__ = ["is_configured", "get_library_path"], "MPITrampolineLocalCluster"]

--- a/src/mpibackend4jax/__init__.py
+++ b/src/mpibackend4jax/__init__.py
@@ -6,30 +6,11 @@ by setting the required environment variables when imported.
 """
 
 import os
-from pathlib import Path
 
 # Import the cluster to register it automatically
 # from .mpitrampoline_cluster import MPITrampolineLocalCluster
 
 __version__ = "0.1.0"
-
-def initialize():
-    # Get the package installation directory
-    _package_dir = Path(__file__).parent
-    _mpiwrapper_lib = _package_dir / "lib" / "libmpiwrapper.so"
-
-    # Set environment variables for MPITrampoline
-    if _mpiwrapper_lib.exists():
-        if "MPITRAMPOLINE_LIB" not in os.environ.keys():
-            os.environ["MPITRAMPOLINE_LIB"] = str(_mpiwrapper_lib.absolute())
-            print(f"mpibackend4jax: Set MPITRAMPOLINE_LIB={_mpiwrapper_lib.absolute()}")
-        if "JAX_CPU_COLLECTIVES_IMPLEMENTATION" not in os.environ.keys()
-            os.environ["JAX_CPU_COLLECTIVES_IMPLEMENTATION"] = "mpi"
-            print("mpibackend4jax: Set JAX_CPU_COLLECTIVES_IMPLEMENTATION=mpi")
-    else:
-        print(f"Warning: MPIWrapper library not found at {_mpiwrapper_lib}")
-        print("Please ensure the package was installed correctly.")
-
 
 # # Convenience function to check if MPITrampoline is properly configured
 # def is_configured():

--- a/src/mpibackend4jax/__init__.py
+++ b/src/mpibackend4jax/__init__.py
@@ -9,39 +9,40 @@ import os
 from pathlib import Path
 
 # Import the cluster to register it automatically
-from .mpitrampoline_cluster import MPITrampolineLocalCluster
+# from .mpitrampoline_cluster import MPITrampolineLocalCluster
 
 __version__ = "0.1.0"
 
-# Get the package installation directory
-_package_dir = Path(__file__).parent
-_mpiwrapper_lib = _package_dir / "lib" / "libmpiwrapper.so"
+def initialize():
+    # Get the package installation directory
+    _package_dir = Path(__file__).parent
+    _mpiwrapper_lib = _package_dir / "lib" / "libmpiwrapper.so"
 
-# Set environment variables for MPITrampoline
-if _mpiwrapper_lib.exists():
-    os.environ["MPITRAMPOLINE_LIB"] = str(_mpiwrapper_lib.absolute())
-    os.environ["JAX_CPU_COLLECTIVES_IMPLEMENTATION"] = "mpi"
+    # Set environment variables for MPITrampoline
+    if _mpiwrapper_lib.exists():
+        os.environ["MPITRAMPOLINE_LIB"] = str(_mpiwrapper_lib.absolute())
+        os.environ["JAX_CPU_COLLECTIVES_IMPLEMENTATION"] = "mpi"
 
-    print(f"mpibackend4jax: Set MPITRAMPOLINE_LIB={_mpiwrapper_lib.absolute()}")
-    print("mpibackend4jax: Set JAX_CPU_COLLECTIVES_IMPLEMENTATION=mpi")
-else:
-    print(f"Warning: MPIWrapper library not found at {_mpiwrapper_lib}")
-    print("Please ensure the package was installed correctly.")
-
-
-# Convenience function to check if MPITrampoline is properly configured
-def is_configured():
-    """Check if MPITrampoline is properly configured for JAX"""
-    return (
-        "MPITRAMPOLINE_LIB" in os.environ
-        and os.environ.get("JAX_CPU_COLLECTIVES_IMPLEMENTATION") == "mpi"
-        and Path(os.environ["MPITRAMPOLINE_LIB"]).exists()
-    )
+        print(f"mpibackend4jax: Set MPITRAMPOLINE_LIB={_mpiwrapper_lib.absolute()}")
+        print("mpibackend4jax: Set JAX_CPU_COLLECTIVES_IMPLEMENTATION=mpi")
+    else:
+        print(f"Warning: MPIWrapper library not found at {_mpiwrapper_lib}")
+        print("Please ensure the package was installed correctly.")
 
 
-def get_library_path():
-    """Get the path to the MPIWrapper library"""
-    return os.environ.get("MPITRAMPOLINE_LIB")
+# # Convenience function to check if MPITrampoline is properly configured
+# def is_configured():
+#     """Check if MPITrampoline is properly configured for JAX"""
+#     return (
+#         "MPITRAMPOLINE_LIB" in os.environ
+#         and os.environ.get("JAX_CPU_COLLECTIVES_IMPLEMENTATION") == "mpi"
+#         and Path(os.environ["MPITRAMPOLINE_LIB"]).exists()
+#     )
+#
+#
+# def get_library_path():
+#     """Get the path to the MPIWrapper library"""
+#     return os.environ.get("MPITRAMPOLINE_LIB")
 
 
-__all__ = ["is_configured", "get_library_path", "MPITrampolineLocalCluster"]
+__all__ = ["is_configured", "get_library_path"]#, "MPITrampolineLocalCluster"]

--- a/src/mpibackend4jax/plugin.py
+++ b/src/mpibackend4jax/plugin.py
@@ -1,0 +1,20 @@
+import os
+from pathlib import Path
+
+
+def initialize():
+    # Get the package installation directory
+    _package_dir = Path(__file__).parent
+    _mpiwrapper_lib = _package_dir / "lib" / "libmpiwrapper.so"
+
+    # Set environment variables for MPITrampoline
+    if _mpiwrapper_lib.exists():
+        if "MPITRAMPOLINE_LIB" not in os.environ.keys():
+            os.environ["MPITRAMPOLINE_LIB"] = str(_mpiwrapper_lib.absolute())
+            print(f"mpibackend4jax: Set MPITRAMPOLINE_LIB={_mpiwrapper_lib.absolute()}")
+        if "JAX_CPU_COLLECTIVES_IMPLEMENTATION" not in os.environ.keys():
+            os.environ["JAX_CPU_COLLECTIVES_IMPLEMENTATION"] = "mpi"
+            print("mpibackend4jax: Set JAX_CPU_COLLECTIVES_IMPLEMENTATION=mpi")
+    else:
+        print(f"Warning: MPIWrapper library not found at {_mpiwrapper_lib}")
+        print("Please ensure the package was installed correctly.")


### PR DESCRIPTION
no import needed.

uses the same mechanism as e.g. the gpu plugin.

See 
https://github.com/jax-ml/jax/blob/13248ce80f448e5a60c2c91dd6a544aae0a81423/jax/_src/xla_bridge.py#L424

Example: 

```python
import os
import jax

print("Setup initialize", flush=True)

jax.distributed.initialize(coordinator_address="127.0.0.1:50000", process_id =int(os.environ['PMI_RANK']), num_processes=int(os.environ['PMI_SIZE']))

print(f"{jax.process_index()}/{jax.process_count()} :", jax.local_devices())
print(f"{jax.process_index()}/{jax.process_count()} :", jax.devices())

x = jax.numpy.ones(
    (jax.device_count(),),
    device=jax.sharding.NamedSharding(
        jax.sharding.Mesh(jax.devices(), "i"), jax.sharding.PartitionSpec("i")
    ),
)

print(f"{jax.process_index()}/{jax.process_count()} :", x.sum())
```

could try to upstream the MPITrampolineLocalCluster to jax as MPICHCluster or whatever